### PR TITLE
Add modal for ban appeal and some other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # DMModBot
 
+### Cloning the Repo
+
+This repo uses git submodules, so when cloning be sure to use:
+
+```bash
+git clone --recurse-submodules
+```
+
 ### Running the bot
 
 1. Create venv if you don't have it already


### PR DESCRIPTION
* Minor refactoring for report room and ban appeal room creation

Currently report rooms are created based on a user's Message, but because the ban appeal form only gives a string, some changes required

* Minor logic changes to deal with some potential edge cases
* Update README with cloning instructions