### PR TITLE
fix(reports): hide moderator number for non-anonymous conversations

### DIFF
--- a/cogs/modbot.py
+++ b/cogs/modbot.py
@@ -702,11 +702,11 @@ class Modbot(commands.Cog):
                 raise hf.EndEarly
 
             if isinstance(open_report.dest, discord.DMChannel):
-                cont = f">>> **Moderator {thread_info['mods'].index(msg.author.id) + 1}"
+
                 if thread_info.setdefault('not_anonymous', False):
-                    cont += f" ({msg.author.mention}):** "
+                    cont = f" {msg.author.mention}: "
                 else:
-                    cont += ":** "
+                    cont = f">>> **Moderator {thread_info['mods'].index(msg.author.id) + 1}**: "
             else:
                 cont = f">>> {msg.author.mention}: "
 


### PR DESCRIPTION
Don't display the moderator number when the ticket session is not anonymous, especially if you plan to make the conversation anonymous again afterwards

Before:
> **Moderator 1**: This is an anonymous message
> Evil (Moderator 1): This is a non-anonymous message
> **Moderator 1**: This is an anonymous message again

You can tell that Moderator 1 was Evil, and after switching back to anonymous, you can still recognize it's the same person

Now:
> **Moderator 1**: This is an anonymous message
> Evil: This is a non-anonymous message
> **Moderator 1**: This is an anonymous message again

The "Moderator + index" string is removed if `not_anonymous` is set to true